### PR TITLE
Modify 404 behaviour for CMS Managed Media Items

### DIFF
--- a/src/Unic.ErrorManager.Core/Controls/BaseError.cs
+++ b/src/Unic.ErrorManager.Core/Controls/BaseError.cs
@@ -90,14 +90,14 @@ namespace Unic.ErrorManager.Core.Controls
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-
+            var isUsingStatic = Sitecore.Configuration.Settings.GetBoolSetting(SettingsKey + ".UseStatic", false);
             // initial parameters
             Language lang = UrlUtil.ResolveLanguage();
             SiteContext site = UrlUtil.ResolveSite(lang);
             string url = string.Empty;
 
             // Use the static error page if the site or the database is not available
-            if (site == null || site.Database == null)
+            if (isUsingStatic || site == null || site.Database == null)
             {
                 url = Sitecore.Web.WebUtil.GetServerUrl() + Settings.GetSetting(this.SettingsKey + ".Static");
             }

--- a/src/Unic.ErrorManager.Core/Resources/Media/MediaRequestHandler.cs
+++ b/src/Unic.ErrorManager.Core/Resources/Media/MediaRequestHandler.cs
@@ -141,10 +141,12 @@ namespace Unic.ErrorManager.Core.Resources.Media
             {
                 if (Sitecore.Configuration.Settings.RequestErrors.UseServerSideRedirect)
                 {
+                    HttpContext.Current.Items["IsMedia"] = "true";
                     HttpContext.Current.Server.Transfer(redirect);
                 }
                 else
                 {
+                    Sitecore.Web.WebUtil.AddQueryString(redirect, "IsMedia", "true");
                     HttpContext.Current.Response.Redirect(redirect);
                 }
 

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -85,6 +85,11 @@
       <setting name="ItemNotFoundUrl.Static" value="/sitecore modules/Web/Error Manager/service/notfound.aspx" />
       <setting name="ItemNotFoundUrl.Item" value="/error/notfound" />
 
+      <!--  MEDIA NOT FOUND HANDLER -->
+      <setting name="MediaNotFoundUrl.Static" value="/sitecore modules/Web/Error Manager/service/notfound.aspx" />
+      <setting name="MediaNotFoundUrl.Item" value="/error/notfound" />
+      <setting name="MediaNotFoundUrl.UseStatic" value="false" />
+
       <!--  LAYOUT NOT FOUND HANDLER
             Url of page handling 'Layout not found' errors
       -->

--- a/src/Unic.ErrorManager.Website/sitecore modules/Web/Error Manager/404.aspx.cs
+++ b/src/Unic.ErrorManager.Website/sitecore modules/Web/Error Manager/404.aspx.cs
@@ -31,7 +31,10 @@ namespace Unic.ErrorManager.Website.sitecore_modules.Web.Error_Manager
         protected override void OnLoad(EventArgs e)
         {
             // set properties
-            base.SettingsKey = "ItemNotFoundUrl";
+            var isMedia = Context.Items.Contains("IsMedia")
+                ? Convert.ToBoolean(Context.Items["IsMedia"])
+                : Sitecore.Web.WebUtil.GetItemsBool("IsMedia", false);
+            base.SettingsKey = isMedia ? "MediaNotFoundUrl" : "ItemNotFoundUrl";
             base.StatusCode = 404;
 
             // go


### PR DESCRIPTION
* Allow different NotFoundUrl between media and item
* Introduce MediaNotFoundUrl.UseStatic as preset for static url