### PR TITLE
Feature/add error page personalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 8.1
 
-- New feature: Support for personalization on error pages. Too enable this feature, you need to set the "ErrorManager.DisableTracking" setting to false.
+- New feature: Support for personalization on error pages. To enable this feature, you need to set the "ErrorManager.DisableTracking" setting to false.
 - Allow different NotFoundUrl between media requests and non-media requests
 - Introduce MediaNotFoundUrl.UseStatic as preset for static url
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.1
+
+- New feature: Support for personalization on error pages. Too enable this feature, you need to set the "ErrorManager.DisableTracking" setting to false.
+- Allow different NotFoundUrl between media requests and non-media requests
+- Introduce MediaNotFoundUrl.UseStatic as preset for static url
+
 # 8.0.3
 
 - suppress infinite loop by checking target URL and requested ones, if "AbsolutePath" is same, go to layout static page

--- a/src/Unic.ErrorManager.Core/Controls/BaseError.cs
+++ b/src/Unic.ErrorManager.Core/Controls/BaseError.cs
@@ -273,7 +273,7 @@ namespace Unic.ErrorManager.Core.Controls
             var userAgent = Settings.GetSetting(Definitions.Constants.UserAgentSetting);
             if (string.IsNullOrWhiteSpace(userAgent)) return;
 
-            request.Headers.Add("User-Agent", userAgent);
+            request.UserAgent = userAgent;
         }
 
         private void HandleHeaderForwarding(HttpWebRequest request)

--- a/src/Unic.ErrorManager.Core/Controls/BaseError.cs
+++ b/src/Unic.ErrorManager.Core/Controls/BaseError.cs
@@ -169,6 +169,12 @@ namespace Unic.ErrorManager.Core.Controls
                 this.AddRequestCookies(request);
             }
 
+            // add user-agent to the request
+            if (Settings.GetBoolSetting(Definitions.Constants.AddUserAgentHeaderSetting, true))
+            {
+                this.AddUserAgentHeader(request);
+            }
+
             // handle header forwarding
             this.HandleHeaderForwarding(request);
 
@@ -260,6 +266,14 @@ namespace Unic.ErrorManager.Core.Controls
             }
 
             return new NetworkCredential(username, password);
+        }
+
+        protected virtual void AddUserAgentHeader(HttpWebRequest request)
+        {
+            var userAgent = Settings.GetSetting(Definitions.Constants.UserAgentSetting);
+            if (string.IsNullOrWhiteSpace(userAgent)) return;
+
+            request.Headers.Add("User-Agent", userAgent);
         }
 
         private void HandleHeaderForwarding(HttpWebRequest request)

--- a/src/Unic.ErrorManager.Core/Definitions/Constants.cs
+++ b/src/Unic.ErrorManager.Core/Definitions/Constants.cs
@@ -6,14 +6,18 @@
 
         public static string DisableTrackingParameterValueSetting = "ErrorManager.DisableTrackingParameterValue";
 
+        public static string DisableTrackingSetting = "ErrorManager.DisableTracking";
+
         public static string DisplayModeParameterName = "sc_mode";
 
         public static string DisplayModeParameterValueSetting = "normal";
 
-        public static string DisableTrackingSetting = "DisableTracking";
-
-        public static string ErrorManagerUserAgentSetting = "ErrorManagerUserAgent";
-
         public static string IsMediaParameterName = "IsMedia";
+
+        public static string UserAgentSetting = "ErrorManager.UserAgent";
+
+        public static string AddUserAgentHeaderSetting = "ErrorManager.AddUserAgentHeader";
+
+        public static string EnableAgentHeaderCheckSetting = "ErrorManager.EnableAgentHeaderCheck";
     }
 }

--- a/src/Unic.ErrorManager.Core/Definitions/Constants.cs
+++ b/src/Unic.ErrorManager.Core/Definitions/Constants.cs
@@ -10,8 +10,8 @@
 
         public static string DisplayModeParameterValueSetting = "normal";
 
-        public static string EnableDisableTrackingSetting = "EnableDisableTracking";
+        public static string DisableTrackingSetting = "DisableTracking";
 
-        public static string RedirectRequestBotSetting = "EnableDisableTracking";
+        public static string ErrorManagerUserAgentSetting = "ErrorManagerUserAgent";
     }
 }

--- a/src/Unic.ErrorManager.Core/Definitions/Constants.cs
+++ b/src/Unic.ErrorManager.Core/Definitions/Constants.cs
@@ -9,5 +9,9 @@
         public static string DisplayModeParameterName = "sc_mode";
 
         public static string DisplayModeParameterValueSetting = "normal";
+
+        public static string EnableDisableTrackingSetting = "EnableDisableTracking";
+
+        public static string RedirectRequestBotSetting = "EnableDisableTracking";
     }
 }

--- a/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
@@ -1,24 +1,33 @@
-﻿using System;
-using System.Web;
-using Sitecore.Analytics.Pipelines.ExcludeRobots;
-using Sitecore.Configuration;
-using Sitecore.Diagnostics;
-using Unic.ErrorManager.Core.Definitions;
-
-namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
+﻿namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
 {
+    using System;
+    using System.Web;
+    using Sitecore;
+    using Sitecore.Analytics.Pipelines.ExcludeRobots;
+    using Sitecore.Configuration;
+    using Sitecore.Diagnostics;
+    using Constants = Definitions.Constants;
+
+    [UsedImplicitly]
     public class CheckErrorManagerUserAgent : ExcludeRobotsProcessor
     {
+        private HttpContextBase context;
+
         public HttpContextBase HttpContext
         {
             get
             {
-                if (System.Web.HttpContext.Current != null)
+                if (this.context != null)
                 {
-                    return new HttpContextWrapper(System.Web.HttpContext.Current);
+                    return this.context;
                 }
 
-                return null;
+                if (System.Web.HttpContext.Current == null)
+                {
+                    return null;
+                }
+
+                return this.context = new HttpContextWrapper(System.Web.HttpContext.Current);
             }
         }
 
@@ -28,9 +37,10 @@ namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
 
             var httpContext = this.HttpContext;
             var userAgent = httpContext.Request.UserAgent;
+            var userAgentSetting = Settings.GetSetting(Constants.ErrorManagerUserAgentSetting);
 
-            if (userAgent == null || !string.Equals(Settings.GetSetting(Constants.ErrorManagerUserAgentSetting), userAgent, StringComparison.InvariantCultureIgnoreCase)) return;
-            
+            if (userAgent == null || !string.Equals(userAgentSetting, userAgent, StringComparison.InvariantCultureIgnoreCase)) return;
+
             args.IsInExcludeList = true;
         }
     }

--- a/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
@@ -35,13 +35,24 @@
         {
             Assert.ArgumentNotNull(args, nameof(args));
 
-            var httpContext = this.HttpContext;
-            var userAgent = httpContext.Request.UserAgent;
-            var userAgentSetting = Settings.GetSetting(Constants.ErrorManagerUserAgentSetting);
+            if (!this.ShouldExecute()) return;
 
-            if (userAgent == null || !string.Equals(userAgentSetting, userAgent, StringComparison.InvariantCultureIgnoreCase)) return;
+            var request = this.HttpContext?.Request;
+            args.IsInExcludeList = this.CheckUserAgent(request);
+        }
 
-            args.IsInExcludeList = true;
+        protected virtual bool ShouldExecute()
+        {
+            return Settings.GetBoolSetting(Constants.EnableAgentHeaderCheckSetting, true);
+        }
+
+        protected virtual bool CheckUserAgent(HttpRequestBase request)
+        {
+            var userAgent = request?.UserAgent;
+            if (userAgent == null) return false;
+
+            var userAgentSetting = Settings.GetSetting(Constants.UserAgentSetting);
+            return string.Equals(userAgent, userAgentSetting, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
@@ -1,4 +1,6 @@
-﻿using Sitecore.Analytics.Pipelines.ExcludeRobots;
+﻿using System;
+using System.Web;
+using Sitecore.Analytics.Pipelines.ExcludeRobots;
 using Sitecore.Configuration;
 using Sitecore.Diagnostics;
 using Unic.ErrorManager.Core.Definitions;
@@ -7,13 +9,28 @@ namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
 {
     public class CheckErrorManagerUserAgent : ExcludeRobotsProcessor
     {
+        public HttpContextBase HttpContext
+        {
+            get
+            {
+                if (System.Web.HttpContext.Current != null)
+                {
+                    return new HttpContextWrapper(System.Web.HttpContext.Current);
+                }
+
+                return null;
+            }
+        }
+
         public override void Process(ExcludeRobotsArgs args)
         {
-            Assert.ArgumentNotNull((object)args, nameof(args));
-            Assert.IsNotNull((object)args.HttpContext, "HttpContext");
-            Assert.IsNotNull((object)args.HttpContext.Request, "Request");
-            if (args.HttpContext.Request.UserAgent == null || Settings.GetSetting(Constants.RedirectRequestBotSetting) != args.HttpContext.Request.UserAgent)
-                return;
+            Assert.ArgumentNotNull(args, nameof(args));
+
+            var httpContext = this.HttpContext;
+            var userAgent = httpContext.Request.UserAgent;
+
+            if (userAgent == null || !string.Equals(Settings.GetSetting(Constants.ErrorManagerUserAgentSetting), userAgent, StringComparison.InvariantCultureIgnoreCase)) return;
+            
             args.IsInExcludeList = true;
         }
     }

--- a/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/CheckErrorManagerUserAgent.cs
@@ -1,0 +1,20 @@
+﻿using Sitecore.Analytics.Pipelines.ExcludeRobots;
+using Sitecore.Configuration;
+using Sitecore.Diagnostics;
+using Unic.ErrorManager.Core.Definitions;
+
+namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
+{
+    public class CheckErrorManagerUserAgent : ExcludeRobotsProcessor
+    {
+        public override void Process(ExcludeRobotsArgs args)
+        {
+            Assert.ArgumentNotNull((object)args, nameof(args));
+            Assert.IsNotNull((object)args.HttpContext, "HttpContext");
+            Assert.IsNotNull((object)args.HttpContext.Request, "Request");
+            if (args.HttpContext.Request.UserAgent == null || Settings.GetSetting(Constants.RedirectRequestBotSetting) != args.HttpContext.Request.UserAgent)
+                return;
+            args.IsInExcludeList = true;
+        }
+    }
+}

--- a/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/ItemResolver.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/ItemResolver.cs
@@ -40,12 +40,13 @@ namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
         /// <param name="args">Http request arguments.</param>
         public override void Process(HttpRequestArgs args)
         {
-            System.Web.HttpContext.Current.Request.Headers.Add("user-agent", Settings.GetSetting(Constants.RedirectRequestBotSetting));
 
             if (Sitecore.Context.Item == null || Sitecore.Context.Database == null)
             {
                 return;
             }
+
+            System.Web.HttpContext.Current.Request.Headers.Add("User-Agent", Settings.GetSetting(Constants.DisableTrackingSetting));
 
             // check for requets on /sitecore/content and show 404 if request contains the string
             if (Sitecore.Context.PageMode.IsNormal && Sitecore.Context.GetSiteName() != "shell" && Sitecore.Web.WebUtil.GetRawUrl().IndexOf("/sitecore/content") > -1)

--- a/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/ItemResolver.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/ItemResolver.cs
@@ -12,15 +12,11 @@
 
 #endregion
 
-using Sitecore;
-using Sitecore.Configuration;
-using Constants = Unic.ErrorManager.Core.Definitions.Constants;
-
 namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
 {
+    using Sitecore;
     using Sitecore.Pipelines.HttpRequest;
-
-    using Unic.ErrorManager.Core.Extensions;
+    using Extensions;
 
     /// <summary>
     /// Pipeline processor to resolve if the resolved context item has a valid language version. You can speficy available (valid) languages
@@ -31,6 +27,7 @@ namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
     /// Please see <c>Unic.Modules.ErrorManager.config</c> for a configuration example.
     /// </summary>
     /// <author>Kevin Brechbühl - Unic AG</author>
+    [UsedImplicitly]
     public class ItemResolver : HttpRequestProcessor
     {
         /// <summary>
@@ -40,13 +37,10 @@ namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
         /// <param name="args">Http request arguments.</param>
         public override void Process(HttpRequestArgs args)
         {
-
             if (Sitecore.Context.Item == null || Sitecore.Context.Database == null)
             {
                 return;
             }
-
-            System.Web.HttpContext.Current.Request.Headers.Add("User-Agent", Settings.GetSetting(Constants.DisableTrackingSetting));
 
             // check for requets on /sitecore/content and show 404 if request contains the string
             if (Sitecore.Context.PageMode.IsNormal && Sitecore.Context.GetSiteName() != "shell" && Sitecore.Web.WebUtil.GetRawUrl().IndexOf("/sitecore/content") > -1)
@@ -59,7 +53,7 @@ namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
             if (Sitecore.Context.Item != null &&
                 !Sitecore.Context.PageMode.IsExperienceEditor &&
                 Sitecore.Context.Site.Name != "shell" &&
-                (System.Web.HttpContext.Current.Request.ServerVariables["SCRIPT_NAME"] != "/default.aspx" || 
+                (System.Web.HttpContext.Current.Request.ServerVariables["SCRIPT_NAME"] != "/default.aspx" ||
                 Sitecore.Web.WebUtil.GetRawUrl() == "/" + Sitecore.Context.Language))
             {
                 if (!Sitecore.Context.Item.HasLanguageVersion(Sitecore.Context.Language, Sitecore.Context.Site.Properties["availableLanguages"]))

--- a/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/ItemResolver.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/HttpRequest/ItemResolver.cs
@@ -12,6 +12,10 @@
 
 #endregion
 
+using Sitecore;
+using Sitecore.Configuration;
+using Constants = Unic.ErrorManager.Core.Definitions.Constants;
+
 namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
 {
     using Sitecore.Pipelines.HttpRequest;
@@ -36,6 +40,8 @@ namespace Unic.ErrorManager.Core.Pipelines.HttpRequest
         /// <param name="args">Http request arguments.</param>
         public override void Process(HttpRequestArgs args)
         {
+            System.Web.HttpContext.Current.Request.Headers.Add("user-agent", Settings.GetSetting(Constants.RedirectRequestBotSetting));
+
             if (Sitecore.Context.Item == null || Sitecore.Context.Database == null)
             {
                 return;

--- a/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
@@ -1,4 +1,6 @@
-﻿using Sitecore.Configuration;
+﻿using System;
+using Sitecore.Common;
+using Sitecore.Configuration;
 using Sitecore.Pipelines;
 using Sitecore.Web;
 using Unic.ErrorManager.Core.Definitions;
@@ -12,7 +14,13 @@ namespace Unic.ErrorManager.Core.Pipelines.StartAnalytics
     {
         public virtual void Process(PipelineArgs args)
         {
-            var disableTrackingValue = WebUtil.GetQueryString(Constants.DisableTrackingParameterName);
+            var disableTrackingValue = string.Empty;
+
+            if (Convert.ToBoolean(Settings.GetSetting(Constants.EnableDisableTrackingSetting)))
+            {
+                disableTrackingValue = WebUtil.GetQueryString(Constants.DisableTrackingParameterName);
+            }
+
             if (!string.IsNullOrEmpty(disableTrackingValue) 
                 && disableTrackingValue.Equals(Settings.GetSetting(Constants.DisableTrackingParameterValueSetting, string.Empty)))
             {

--- a/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
@@ -16,7 +16,7 @@ namespace Unic.ErrorManager.Core.Pipelines.StartAnalytics
         {
             var disableTrackingValue = string.Empty;
 
-            if (Convert.ToBoolean(Settings.GetSetting(Constants.EnableDisableTrackingSetting)))
+            if (Convert.ToBoolean(Settings.GetSetting(Constants.DisableTrackingSetting)))
             {
                 disableTrackingValue = WebUtil.GetQueryString(Constants.DisableTrackingParameterName);
             }

--- a/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using Sitecore.Common;
-using Sitecore.Configuration;
-using Sitecore.Diagnostics;
-using Sitecore.Pipelines;
-using Sitecore.Web;
-using Unic.ErrorManager.Core.Definitions;
-
-namespace Unic.ErrorManager.Core.Pipelines.StartAnalytics
+﻿namespace Unic.ErrorManager.Core.Pipelines.StartAnalytics
 {
+    using System;
+    using Sitecore.Configuration;
+    using Sitecore.Diagnostics;
+    using Sitecore.Pipelines;
+    using Sitecore.Web;
+    using Definitions;
+
     /// <summary>
     /// Disables the xDB tracker for requests from the error manager to the error pages due to session locks
     /// </summary>

--- a/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
+++ b/src/Unic.ErrorManager.Core/Pipelines/StartAnalytics/DisableRequestTracking.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Sitecore.Common;
 using Sitecore.Configuration;
+using Sitecore.Diagnostics;
 using Sitecore.Pipelines;
 using Sitecore.Web;
 using Unic.ErrorManager.Core.Definitions;
@@ -14,18 +15,28 @@ namespace Unic.ErrorManager.Core.Pipelines.StartAnalytics
     {
         public virtual void Process(PipelineArgs args)
         {
-            var disableTrackingValue = string.Empty;
+            Assert.ArgumentNotNull(args, nameof(args));
 
-            if (Convert.ToBoolean(Settings.GetSetting(Constants.DisableTrackingSetting)))
-            {
-                disableTrackingValue = WebUtil.GetQueryString(Constants.DisableTrackingParameterName);
-            }
+            if (!this.ShouldExecute()) return;
 
-            if (!string.IsNullOrEmpty(disableTrackingValue) 
-                && disableTrackingValue.Equals(Settings.GetSetting(Constants.DisableTrackingParameterValueSetting, string.Empty)))
+            if (this.ShouldDisableTracking())
             {
                 args.AbortPipeline();
             }
+        }
+
+        protected virtual bool ShouldExecute()
+        {
+            return Settings.GetBoolSetting(Constants.DisableTrackingSetting, true);
+        }
+
+        protected virtual bool ShouldDisableTracking()
+        {
+            var disableTrackingParameterValueQuery = WebUtil.GetQueryString(Constants.DisableTrackingParameterName);
+            if (string.IsNullOrWhiteSpace(disableTrackingParameterValueQuery)) return false;
+
+            var disableTrackingParameterValue = Settings.GetSetting(Constants.DisableTrackingParameterValueSetting);
+            return string.Equals(disableTrackingParameterValueQuery, disableTrackingParameterValue, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/Unic.ErrorManager.Core/Unic.ErrorManager.Core.csproj
+++ b/src/Unic.ErrorManager.Core/Unic.ErrorManager.Core.csproj
@@ -65,6 +65,7 @@
     </Compile>
     <Compile Include="Definitions\Constants.cs" />
     <Compile Include="Extensions\ItemExtension.cs" />
+    <Compile Include="Pipelines\HttpRequest\CheckErrorManagerUserAgent.cs" />
     <Compile Include="Pipelines\HttpRequest\ItemResolver.cs" />
     <Compile Include="Pipelines\StartAnalytics\DisableRequestTracking.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -115,7 +115,7 @@
       <!-- BOT SEETINGS
            Defines the Bot for the redirect request
       -->
-      <setting name="ErrorManager.UserAgent" set:value="ErrorManagerUserAgent" />
+      <setting name="ErrorManager.UserAgent" set:value="SitecoreErrorManager" />
       <setting name="ErrorManager.AddUserAgentHeader" set:value="true" />
       <setting name="ErrorManager.EnableAgentHeaderCheck" set:value="true" />
 

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -130,22 +130,29 @@
               NOTE: If you do not use the general ItemResolver, please change the "patch:after" attribute. If you use some
               other item resolving in your project, you have to include this pipeline after your custom resolver.
         -->
-        <processor  patch:after="processor[@type='Sitecore.Pipelines.HttpRequest.ItemResolver, Sitecore.Kernel']"
-                    type="Unic.ErrorManager.Core.Pipelines.HttpRequest.ItemResolver, Unic.ErrorManager.Core" />
+        <processor patch:after="processor[@type='Sitecore.Pipelines.HttpRequest.ItemResolver, Sitecore.Kernel']"
+                   type="Unic.ErrorManager.Core.Pipelines.HttpRequest.ItemResolver, Unic.ErrorManager.Core" />
 
       </httpRequestBegin>
 
       <excludeRobots>
-        <processor  patch:after="processor[@type='Sitecore.Analytics.Pipelines.ExcludeRobots.TryObtainCachedResult, Sitecore.Analytics']"
-                    type="Unic.ErrorManager.Core.Pipelines.HttpRequest.CheckErrorManagerUserAgent, Unic.ErrorManager.Core" />
+
+        <!--  EXCLUDE ROBOTS PIPELINE
+              Checks the user-agent of the request against the defined error-manager user-agent. In case it matches, the 
+              request is identified as a bot request, which will suppress tracking while still allowing it to be 
+              personalized.
+        -->
+        <processor patch:after="processor[@type='Sitecore.Analytics.Pipelines.ExcludeRobots.TryObtainCachedResult, Sitecore.Analytics']"
+                   type="Unic.ErrorManager.Core.Pipelines.HttpRequest.CheckErrorManagerUserAgent, Unic.ErrorManager.Core" />
       </excludeRobots>
 
       <startAnalytics>
 
         <!--  DISABLE REQUEST TRACKING
-              Prevents the initialization of the xDB Tracker for requests to the error pages trough this module.
+              Prevents the initialization of the xDB Tracker for requests to the error pages through this module.
 
-              NOTE: This is neccessary, as the nested request runs into a analytics session lock for this user.
+              NOTE: This is neccessary for some Sitecore solutions, when the nested request runs into a analytics
+              session lock for this user.
           -->
         <processor patch:after="processor[@type='Sitecore.Analytics.Pipelines.StartAnalytics.CheckPreconditions, Sitecore.Analytics']"
                    type="Unic.ErrorManager.Core.Pipelines.StartAnalytics.DisableRequestTracking, Unic.ErrorManager.Core" />

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -137,8 +137,9 @@
 
       <excludeRobots>
         <processor  patch:after="processor[@type='Sitecore.Analytics.Pipelines.ExcludeRobots.TryObtainCachedResult, Sitecore.Analytics']"
-                  type="Unic.ErrorManager.Core.Pipelines.HttpRequest.CheckErrorManagerUserAgent, Unic.ErrorManager.Core" />
+                    type="Unic.ErrorManager.Core.Pipelines.HttpRequest.CheckErrorManagerUserAgent, Unic.ErrorManager.Core" />
       </excludeRobots>
+
       <startAnalytics>
 
         <!--  DISABLE REQUEST TRACKING

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -77,6 +77,7 @@
             Default value: 7mgpoIhQqV
       -->
       <setting name="ErrorManager.DisableTrackingParameterValue" value="7mgpoIhQqV" />
+      <setting name="ErrorManager.DisableTracking" set:value="true" />
 
       <!--  ITEM NOT FOUND HANDLER
             Url of page handling 'Item not found' errors
@@ -114,10 +115,9 @@
       <!-- BOT SEETINGS
            Defines the Bot for the redirect request
       -->
-      <setting name="ErrorManagerUserAgent" set:value="ErrorManagerUserAgent"></setting>
-
-
-      <setting name="DisableTracking" set:value="true"></setting>
+      <setting name="ErrorManager.UserAgent" set:value="ErrorManagerUserAgent" />
+      <setting name="ErrorManager.AddUserAgentHeader" set:value="true" />
+      <setting name="ErrorManager.EnableAgentHeaderCheck" set:value="true" />
 
     </settings>
 

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -1,4 +1,4 @@
-﻿<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/">
+﻿<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/" xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <sitecore>
     <!-- SAMPLE CONFIGURATION FILE. PLEASE SEE THE DOCUMENTATION FOR MORE INFORMATIONS -->
 
@@ -106,6 +106,14 @@
       -->
       <setting name="NoLicenseUrl" set:value="/sitecore modules/Web/Error Manager/service/nolicense.aspx" />
 
+      <!-- BOT SEETINGS
+           Defines the Bot for the redirect request
+      -->
+      <setting name="ErrorManagerUserAgent" set:value="ErrorManagerUserAgent"></setting>
+
+
+      <setting name="EnableDisableTracking" set:value="true"></setting>
+
     </settings>
 
     <pipelines>
@@ -120,19 +128,21 @@
         <processor  patch:after="processor[@type='Sitecore.Pipelines.HttpRequest.ItemResolver, Sitecore.Kernel']"
                     type="Unic.ErrorManager.Core.Pipelines.HttpRequest.ItemResolver, Unic.ErrorManager.Core" />
 
+        <processor  patch:after="processor[@type='Sitecore.Pipelines.HttpRequest.ItemResolver, Sitecore.Kernel']"
+                    type="Unic.ErrorManager.Core.Pipelines.HttpRequest.CheckErrorManagerUserAgent, Unic.ErrorManager.Core" />
+
       </httpRequestBegin>
 
       <startAnalytics>
-        
-          <!--  DISABLE REQUEST TRACKING
+
+        <!--  DISABLE REQUEST TRACKING
               Prevents the initialization of the xDB Tracker for requests to the error pages trough this module.
 
               NOTE: This is neccessary, as the nested request runs into a analytics session lock for this user.
           -->
-          <processor patch:after="processor[@type='Sitecore.Analytics.Pipelines.StartAnalytics.CheckPreconditions, Sitecore.Analytics']"
-                     type="Unic.ErrorManager.Core.Pipelines.StartAnalytics.DisableRequestTracking, Unic.ErrorManager.Core" />
-        </startAnalytics>
+        <processor patch:after="processor[@type='Sitecore.Analytics.Pipelines.StartAnalytics.CheckPreconditions, Sitecore.Analytics']"
+                   type="Unic.ErrorManager.Core.Pipelines.StartAnalytics.DisableRequestTracking, Unic.ErrorManager.Core" />
+      </startAnalytics>
     </pipelines>
-
   </sitecore>
 </configuration>

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -112,7 +112,7 @@
       <setting name="ErrorManagerUserAgent" set:value="ErrorManagerUserAgent"></setting>
 
 
-      <setting name="EnableDisableTracking" set:value="true"></setting>
+      <setting name="DisableTracking" set:value="true"></setting>
 
     </settings>
 
@@ -128,11 +128,12 @@
         <processor  patch:after="processor[@type='Sitecore.Pipelines.HttpRequest.ItemResolver, Sitecore.Kernel']"
                     type="Unic.ErrorManager.Core.Pipelines.HttpRequest.ItemResolver, Unic.ErrorManager.Core" />
 
-        <processor  patch:after="processor[@type='Sitecore.Pipelines.HttpRequest.ItemResolver, Sitecore.Kernel']"
-                    type="Unic.ErrorManager.Core.Pipelines.HttpRequest.CheckErrorManagerUserAgent, Unic.ErrorManager.Core" />
-
       </httpRequestBegin>
 
+      <excludeRobots>
+        <processor  patch:after="processor[@type='Sitecore.Analytics.Pipelines.ExcludeRobots.TryObtainCachedResult, Sitecore.Analytics']"
+                  type="Unic.ErrorManager.Core.Pipelines.HttpRequest.CheckErrorManagerUserAgent, Unic.ErrorManager.Core" />
+      </excludeRobots>
       <startAnalytics>
 
         <!--  DISABLE REQUEST TRACKING

--- a/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
+++ b/src/Unic.ErrorManager.Website/App_Config/Include/01_modules/Unic.ErrorManager.config
@@ -151,7 +151,7 @@
         <!--  DISABLE REQUEST TRACKING
               Prevents the initialization of the xDB Tracker for requests to the error pages through this module.
 
-              NOTE: This is neccessary for some Sitecore solutions, when the nested request runs into a analytics
+              NOTE: This is neccessary for some Sitecore solutions, when the nested request runs into an analytics
               session lock for this user.
           -->
         <processor patch:after="processor[@type='Sitecore.Analytics.Pipelines.StartAnalytics.CheckPreconditions, Sitecore.Analytics']"

--- a/src/Unic.ErrorManager.Website/Unic.ErrorManager.Website.csproj
+++ b/src/Unic.ErrorManager.Website/Unic.ErrorManager.Website.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.5\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.5\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -26,6 +28,9 @@
     <IISExpressUseClassicPipelineMode />
     <TargetFrameworkProfile />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,6 +58,9 @@
     <CodeAnalysisRuleSet>..\..\Unic.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.5\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sitecore.Kernel.NoReferences.8.1.151207\lib\NET45\Sitecore.Kernel.dll</HintPath>
@@ -153,6 +161,13 @@
   <PropertyGroup>
     <AssemblySearchPaths>..\..\lib\; $(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.5\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.5\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
    

--- a/src/Unic.ErrorManager.Website/packages.config
+++ b/src/Unic.ErrorManager.Website/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.5" targetFramework="net45" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
   <package id="Sitecore.Kernel.NoReferences" version="8.1.151207" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/Unic.ErrorManager.Website/sitecore modules/Web/Error Manager/404.aspx.cs
+++ b/src/Unic.ErrorManager.Website/sitecore modules/Web/Error Manager/404.aspx.cs
@@ -18,7 +18,7 @@ using Unic.ErrorManager.Core.Definitions;
 
 namespace Unic.ErrorManager.Website.sitecore_modules.Web.Error_Manager
 {
-    using Unic.ErrorManager.Core.Controls;
+    using Core.Controls;
 
     /// <summary>
     /// Page for status code 404 (notfound). It inherits from the <see cref="BaseError"/>, which does all needed stuff.
@@ -41,13 +41,15 @@ namespace Unic.ErrorManager.Website.sitecore_modules.Web.Error_Manager
         protected virtual bool IsMediaRequest()
         {
             var isMedia = this.Context.Items[Constants.IsMediaParameterName];
-            if (isMedia is bool isMediaRequest)
+            if (isMedia is bool)
             {
-                return isMediaRequest;
+                return (bool)isMedia;
             }
 
             var isMediaQueryString = WebUtil.GetQueryString(Constants.IsMediaParameterName);
-            return bool.TryParse(isMediaQueryString, out var isMediaQuery) && isMediaQuery;
+
+            bool isMediaQuery;
+            return bool.TryParse(isMediaQueryString, out isMediaQuery) && isMediaQuery;
         }
     }
 }


### PR DESCRIPTION
This PR enables personalization on error page by adding a custom user-agent in the request, which will be evaluated to identify the request as a bot. This allows personalization, while not triggering any tracking.

The release notes for the upcoming release have been prepared.