### PR TITLE
Remove Unwanted White Space on Not Found Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.3
+
+- Fix unwanted white space on not found pages due to img element not being hidden
+
 # 8.1.2
 
 - More logging on server error

--- a/NuGet.config
+++ b/NuGet.config
@@ -8,5 +8,6 @@
     </packageRestore>
     <packageSources>
         <add key="Sitecore NuGet Feed" value="https://sitecore.myget.org/F/sc-packages/api/v3/index.json" />
+        <add key="Nuget" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>

--- a/src/Unic.ErrorManager.Core/Controls/BaseError.cs
+++ b/src/Unic.ErrorManager.Core/Controls/BaseError.cs
@@ -236,7 +236,7 @@ namespace Unic.ErrorManager.Core.Controls
                 if (Settings.GetBoolSetting("Xdb.Enabled", false) && site.Tracking().EnableTracking)
                 {
                     body = body.Replace("</body>",
-                        string.Format("<img src=\"{0}?{1}\" height=\"1\" width=\"1\" border=\"0\"></body>",
+                        string.Format("<img src=\"{0}?{1}\" style=\"display: none;\"></body>",
                             Settings.GetSetting(this.SettingsKey + ".Static"),
                             base.Request.QueryString));
                 }


### PR DESCRIPTION
This branch fixes the unwanted white space that's caused by the workaround explained here: https://support.sitecore.com/csm?id=csm_ticket&sys_id=feb7697edbf0801094a6ef905b9619eb&table=sn_customerservice_case

**Before**
![image](https://user-images.githubusercontent.com/32507894/191274150-769ab17f-4585-468e-a428-4f756bcd7c94.png)

**After**
![image](https://user-images.githubusercontent.com/32507894/191274476-34fec112-f23b-464c-b956-1bec377661c0.png)
